### PR TITLE
Performance improvements to XLog generation and Trace attributes addition operators

### DIFF
--- a/RapidProM/src/org/rapidprom/operators/conversion/ExampleSetToXLogConversionOperator.java
+++ b/RapidProM/src/org/rapidprom/operators/conversion/ExampleSetToXLogConversionOperator.java
@@ -19,6 +19,7 @@ import org.deckfour.xes.extension.std.XLifecycleExtension;
 import org.deckfour.xes.extension.std.XOrganizationalExtension;
 import org.deckfour.xes.extension.std.XTimeExtension;
 import org.deckfour.xes.factory.XFactory;
+import org.deckfour.xes.factory.XFactoryBufferedImpl;
 import org.deckfour.xes.factory.XFactoryRegistry;
 import org.deckfour.xes.model.XAttributeLiteral;
 import org.deckfour.xes.model.XAttributeMap;
@@ -28,6 +29,7 @@ import org.deckfour.xes.model.XTrace;
 import org.deckfour.xes.model.impl.XAttributeLiteralImpl;
 import org.deckfour.xes.model.impl.XAttributeMapImpl;
 import org.deckfour.xes.model.impl.XAttributeTimestampImpl;
+import org.processmining.xeslite.external.XFactoryExternalStore;
 //import org.processmining.models.xes.XEventPassageClassifier;
 import org.rapidprom.external.connectors.prom.ProMPluginContextManager;
 import org.rapidprom.ioobjects.XLogIOObject;
@@ -312,7 +314,8 @@ public class ExampleSetToXLogConversionOperator extends Operator {
 	}
 
 	private XLog constructLogByExampleSet(ExampleSet data) {
-		XFactory factory = XFactoryRegistry.instance().currentDefault();
+//		XFactory factory = XFactoryRegistry.instance().currentDefault();
+		XFactory factory = new XFactoryExternalStore.MapDBDiskImpl();
 
 		XLog log = createLog(factory, getParameterAsBoolean(
 				PARAMETER_KEY_INCLUDE_EVENT_LIFECYCLE_TRANSITION));

--- a/RapidProM/src/org/rapidprom/operators/logmanipulation/AddTraceAttributesToLogOperator.java
+++ b/RapidProM/src/org/rapidprom/operators/logmanipulation/AddTraceAttributesToLogOperator.java
@@ -1,6 +1,7 @@
 package org.rapidprom.operators.logmanipulation;
 
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.logging.Level;
@@ -107,14 +108,30 @@ public class AddTraceAttributesToLogOperator extends Operator {
 		return parameterTypes;
 	}
 
+	private HashMap<String,XTrace> buildTraceMap(XLog xlog) {
+		HashMap<String,XTrace> map = new HashMap<>();
+		
+		for (XTrace t : xlog) {
+			String name = XConceptExtension.instance().extractName(t);
+			if (name != null) {
+				map.put(name, t);
+			}
+		}
+		
+		return map;
+	}
+	
 	private XLog mergeExampleSetIntoLog(XLog xLog, ExampleSet es,
 			String nameIDcolumn, Attribute idColumnAttrib) throws UndefinedParameterError {
+		
+		HashMap<String,XTrace> traceMap = buildTraceMap(xLog);
+		
 		Iterator<Example> iterator = es.iterator();
 		while (iterator.hasNext()) {
 			Example example = iterator.next();
 			// get the case id and see if a corresponding trace can be found
 			String caseid = example.getValueAsString(idColumnAttrib);
-			XTrace t = findTrace(caseid, xLog);
+			XTrace t = traceMap.get(caseid);
 			if (t != null) {
 				Attributes attributes = example.getAttributes();
 				Iterator<Attribute> iterator2 = attributes.iterator();
@@ -155,16 +172,6 @@ public class AddTraceAttributesToLogOperator extends Operator {
 			}
 		}
 		return xLog;
-	}
-
-	private XTrace findTrace(String caseid, XLog xLog) {
-		for (XTrace t : xLog) {
-			String name = XConceptExtension.instance().extractName(t);
-			if (name.equals(caseid)) {
-				return t;
-			}
-		}
-		return null;
 	}
 
 }


### PR DESCRIPTION
For the "Add attributes to traces" operator, I modified the way traces are searched. Before, in the worse case scenario, the algorithm had a cost of n*m, being n the number of attribute sets and m the number of traces. Now, building a HashMap of the traces indexed by the trace identifier, the cost is n+m. The difference in running time is huge.

For the operator that builds XES logs from tables of events, the implementation has been changed to make use of the MapDB version of XES. This saves a lot of memory and allows to build logs that otherwise would not fit in RAM.
