### PR TITLE
Performance improvements to XLog generation and Trace attributes addition operators

### DIFF
--- a/RapidProM/ivy.xml
+++ b/RapidProM/ivy.xml
@@ -46,6 +46,8 @@
         <dependency org="org.rapidprom" name="Uma" rev="6.5.46" rapidprom:release="3.0.8" />
         <dependency org="org.rapidprom" name="Woflan" rev="6.5.44" rapidprom:release="3.0.8" />
         <dependency org="org.rapidprom" name="XESLite" rev="6.5.168" rapidprom:release="3.0.8" />
+        <dependency org="db-process-mining" name="OpenSLEX" rev="0.6" conf="*"/>
+        <dependency org="db-process-mining" name="DAPOQ-Lang" rev="0.6" conf="*"/>
         <exclude org="*" ext="*" type="source"/>
         <exclude org="*" ext="*" type="javadoc"/>
     </dependencies>

--- a/RapidProM/ivysettings.xml
+++ b/RapidProM/ivysettings.xml
@@ -16,11 +16,27 @@
             <artifact pattern="https://github.com/rapidprom/libraries/raw/master/thirdparty/resource/[module]-[revision]/[module]-[revision].[ext]" />
             <artifact pattern="https://github.com/rapidprom/libraries/raw/master/thirdparty/resource/[module]-[revision]/[module]-[revision]_[os].[ext]" />
         </url>
+        <url name="db-process-mining">
+            <ivy pattern="https://git.yerappa.com/gitbucket/TUE-PhD/DatabaseProcessMining-Repository/raw/master/Releases/[module]/[module]-[revision]-ivy.xml" />
+            <artifact pattern="https://git.yerappa.com/gitbucket/TUE-PhD/DatabaseProcessMining-Repository/raw/master/Releases/[module]/[module]-[revision].[ext]" />
+        </url>
+        <url name="prom" checkmodified="true">
+            <ivy pattern="https://svn.win.tue.nl/repos/[organisation]/Releases/Packages/[module]/[revision]/ivy.xml" />
+            <artifact pattern="https://svn.win.tue.nl/repos/[organisation]/Releases/Packages/[module]/[revision]/[artifact]-[revision].[ext]" />
+        </url>
+        <url name="prom-libs">
+            <ivy pattern="https://svn.win.tue.nl/repos/prom/Libraries/[module]/[revision]/ivy.xml" />
+            <artifact pattern="https://svn.win.tue.nl/repos/prom/Libraries/[module]/[revision]/[artifact]-[revision].[ext]" />
+            <artifact pattern="https://svn.win.tue.nl/repos/prom/Libraries/[module]/[revision]/[artifact]_[revision].[ext]" />
+         </url>
         <ibiblio name="maven2" m2compatible="true"/>
         <chain name="default" returnFirst="true">
             <resolver ref="rapidprom"/>
             <resolver ref="rapidprom-thirdparty-lib"/>
             <resolver ref="rapidprom-thirdparty-resource"/>
+            <resolver ref="db-process-mining"/>
+            <resolver ref="prom"/>
+            <resolver ref="prom-libs"/>
             <resolver ref="maven2"/>  
         </chain>  
     </resolvers>

--- a/RapidProM/resources/org/rapidprom/definitions/ioobject_definitions.xml
+++ b/RapidProM/resources/org/rapidprom/definitions/ioobject_definitions.xml
@@ -175,4 +175,14 @@
 		class="org.rapidprom.ioobjects.streams.XSRunnableIOObject"
 		reportable="false">
 	</ioobject>
+	<ioobject name="SLEXMMIOObject"
+		class="org.rapidprom.ioobjects.SLEXMMIOObject"
+		reportable="false">
+		<renderer>org.rapidprom.ioobjectrenderers.SLEXMMIOObjectRenderer</renderer>
+	</ioobject>
+	<ioobject name="SLEXMMSubSetIOObject"
+		class="org.rapidprom.ioobjects.SLEXMMSubSetIOObject"
+		reportable="false">
+		<renderer>org.rapidprom.ioobjectrenderers.SLEXMMIOSubSetObjectRenderer</renderer>
+	</ioobject>
 </ioobjects>

--- a/RapidProM/resources/org/rapidprom/definitions/operator_definitions.xml
+++ b/RapidProM/resources/org/rapidprom/definitions/operator_definitions.xml
@@ -252,5 +252,19 @@
                 </operator>
             </group>
         </group>
+        <group key="experimental">
+        	<operator>
+        		<key>dapoq_lang_query</key>
+        		<class>org.rapidprom.operators.experimental.DAPOQLangQueryOperator</class>
+        	</operator>
+        	<operator>
+        		<key>import_slex_mm</key>
+        		<class>org.rapidprom.operators.io.ImportSLEXMMOperator</class>
+        	</operator>
+        	<operator>
+        		<key>generate_slex_mm</key>
+        		<class>org.rapidprom.operators.experimental.GenerateSLEXMMOperator</class>
+        	</operator>
+        </group>
     </group>
 </operators>

--- a/RapidProM/resources/org/rapidprom/descriptions/operator_descriptions.xml
+++ b/RapidProM/resources/org/rapidprom/descriptions/operator_descriptions.xml
@@ -404,5 +404,22 @@
 		<help> An Event log is required as input </help>		
         <key>case_data_extractor</key>                
     </operator>
-	
+	<operator>
+	    <name>DAPOQ-Lang Query </name>
+		<synopsis>Executes a DAPOQ-Lang Query on a SLEX Meta Model </synopsis>
+		<help> A SLEX Meta Model is required as input </help>		
+        <key>dapoq_lang_query</key>                
+    </operator>
+    <operator>
+	    <name>SLEXMM Meta Model Importer </name>
+		<synopsis>Imports a SLEX Meta Model </synopsis>
+		<help> A file is required as input </help>		
+        <key>import_slex_mm</key>
+    </operator>
+    <operator>
+	    <name>SLEXMM Meta Model Generator </name>
+		<synopsis>Generates a SLEX Meta Model from several inputs</synopsis>
+		<help>A Data Model, a set of events and versions, logs and process definitions are required as input</help>		
+        <key>generate_slex_mm</key>
+    </operator>
 </operatorHelp>

--- a/RapidProM/src/org/rapidprom/ioobjectrenderers/SLEXMMIOObjectRenderer.java
+++ b/RapidProM/src/org/rapidprom/ioobjectrenderers/SLEXMMIOObjectRenderer.java
@@ -1,0 +1,305 @@
+package org.rapidprom.ioobjectrenderers;
+
+import java.awt.Component;
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.LinkedList;
+import java.util.List;
+
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+
+import org.deckfour.xes.model.XLog;
+import org.processmining.database.metamodel.dapoql.QueryResult;
+import org.processmining.database.metamodel.dapoql.ui.components.MetaModelInspectorPanel;
+import org.processmining.framework.plugin.PluginContext;
+import org.processmining.logprojection.LogProjectionPlugin;
+import org.processmining.logprojection.LogView;
+import org.processmining.logprojection.plugins.dottedchart.ui.DottedChartInspector;
+import org.processmining.openslex.metamodel.SLEXMMStorageMetaModelImpl;
+import org.processmining.plugins.dottedchartanalysis.DottedChartAnalysis;
+import org.processmining.plugins.dottedchartanalysis.model.DottedChartModel;
+import org.processmining.plugins.log.ui.logdialog.LogDialogInitializer;
+import org.processmining.plugins.log.ui.logdialog.SlickerOpenLogSettings;
+import org.rapidprom.external.connectors.prom.ProMPluginContextManager;
+import org.rapidprom.ioobjectrenderers.abstr.AbstractMultipleVisualizersRenderer;
+import org.rapidprom.ioobjects.SLEXMMIOObject;
+import org.rapidprom.ioobjects.SLEXMMSubSetIOObject;
+import org.rapidprom.ioobjects.XLogIOObject;
+import org.rapidprom.util.XLogUtils;
+import org.rapidprom.util.XLogUtils.AttributeTypes;
+import org.rapidprom.util.XLogUtils.TableModelXLog;
+
+import com.rapidminer.example.Attribute;
+import com.rapidminer.example.ExampleSet;
+import com.rapidminer.example.table.AttributeFactory;
+import com.rapidminer.example.table.DataRow;
+import com.rapidminer.example.table.DataRowFactory;
+import com.rapidminer.example.table.MemoryExampleTable;
+import com.rapidminer.gui.renderer.DefaultComponentRenderable;
+import com.rapidminer.gui.renderer.data.ExampleSetDataRenderer;
+import com.rapidminer.operator.IOContainer;
+import com.rapidminer.operator.io.AbstractDataReader.AttributeColumn;
+import com.rapidminer.operator.ports.metadata.AttributeMetaData;
+import com.rapidminer.operator.ports.metadata.ExampleSetMetaData;
+import com.rapidminer.operator.ports.metadata.MDInteger;
+import com.rapidminer.operator.ports.metadata.SetRelation;
+import com.rapidminer.report.Reportable;
+import com.rapidminer.tools.Ontology;
+import com.rapidminer.tools.math.container.Range;
+
+public class SLEXMMIOObjectRenderer extends
+		AbstractMultipleVisualizersRenderer<SLEXMMIOObjectVisualizationType> {
+
+	public SLEXMMIOObjectRenderer() {
+		super(EnumSet.allOf(SLEXMMIOObjectVisualizationType.class),
+				"SLEXMM SubSet renderer");
+	}
+
+//	private Component exampleSetComponent = null;
+//	private WeakReference<XLog> exampleSetLog = null;
+	private Component defaultComponent = null;
+	private WeakReference<SLEXMMStorageMetaModelImpl> defaultMM = null;
+//	private Component dottedChartComponent = null;
+//	private WeakReference<XLog> dottedLog = null;
+//	private Component dottedChartLegacyComponent = null;
+//	private WeakReference<XLog> dottedLegacyLog = null;
+//	private Attribute[] attributes = null;
+
+	protected Component visualizeRendererOption(
+			SLEXMMIOObjectVisualizationType e, Object renderable,
+			IOContainer ioContainer) {
+
+		System.out.println("looking for renderer!");
+		Component result;
+		switch (e) {
+//		case EXAMPLE_SET:
+//			result = createExampleSetComponet(renderable, ioContainer);
+//			break;
+		default:
+		case DEFAULT:
+			result = createDefaultVisualizerComponent(renderable, ioContainer);
+			break;
+		}
+		return result;
+	}
+
+//	protected Component createExampleSetComponet(Object renderable,
+//			IOContainer ioContainer) {
+//		XLogIOObject object = (XLogIOObject) renderable;
+//		XLog log = object.getArtifact();
+//		if (exampleSetComponent == null || exampleSetLog == null
+//				|| !(log.equals(exampleSetLog.get()))) {
+//			MemoryExampleTable table = null;
+//			ExampleSet es = null;
+//
+//			try {
+//				TableModelXLog convertLogToStringTable = XLogUtils
+//						.convertLogToStringTable(object.getArtifact(), true);
+//
+//				table = createStructureTable(convertLogToStringTable);
+//				es = fillTable(table, convertLogToStringTable);
+//
+//			} catch (Exception error) {
+//				error.printStackTrace();
+//			}
+//			ExampleSetDataRenderer renderer = new ExampleSetDataRenderer();
+//			exampleSetComponent = renderer.getVisualizationComponent(es,
+//					ioContainer);
+//			exampleSetLog = new WeakReference<XLog>(log);
+//		}
+//		return exampleSetComponent;
+//	}
+//
+//	private MemoryExampleTable createStructureTable(
+//			TableModelXLog convertedLog) {
+//		ExampleSetMetaData metaData = new ExampleSetMetaData();
+//		List<Attribute> attributes = new LinkedList<Attribute>();
+//		for (int i = 0; i < convertedLog.getColumnCount(); i++) {
+//			String columnName = convertedLog.getColumnName(i);
+//			AttributeTypes columnType = convertedLog.getColumnType(i);
+//			AttributeMetaData amd = null;
+//			if (columnType.equals(AttributeTypes.CONTINUOUS)) {
+//				attributes.add(AttributeFactory.createAttribute(columnName,
+//						Ontology.NUMERICAL));
+//				amd = new AttributeMetaData(columnName, Ontology.NUMERICAL);
+//				amd.setRole(AttributeColumn.REGULAR);
+//				amd.setNumberOfMissingValues(new MDInteger(0));
+//				List<Double> minAndMaxValueColumn = getMinAndMaxValueColumn(
+//						convertedLog, columnName);
+//				amd.setValueRange(
+//						new Range(minAndMaxValueColumn.get(0),
+//								minAndMaxValueColumn.get(1)),
+//						SetRelation.EQUAL);
+//			} else if (columnType.equals(AttributeTypes.DISCRETE)) {
+//				attributes.add(AttributeFactory.createAttribute(columnName,
+//						Ontology.NOMINAL));
+//				amd = new AttributeMetaData(columnName, Ontology.NOMINAL);
+//				amd.setRole(AttributeColumn.REGULAR);
+//				amd.setNumberOfMissingValues(new MDInteger(0));
+//			} else if (columnType.equals(AttributeTypes.DATE)) {
+//				attributes.add(AttributeFactory.createAttribute(columnName,
+//						Ontology.DATE_TIME));
+//				amd = new AttributeMetaData(columnName, Ontology.DATE_TIME);
+//				amd.setRole(AttributeColumn.REGULAR);
+//				amd.setNumberOfMissingValues(new MDInteger(0));
+//				List<Double> minAndMaxValueColumn = getMinAndMaxValueColumn(
+//						convertedLog, columnName);
+//				amd.setValueRange(
+//						new Range(minAndMaxValueColumn.get(0),
+//								minAndMaxValueColumn.get(1)),
+//						SetRelation.EQUAL);
+//			} else if (columnType.equals(AttributeTypes.STRING)) {
+//				attributes.add(AttributeFactory.createAttribute(columnName,
+//						Ontology.NOMINAL));
+//				amd = new AttributeMetaData(columnName, Ontology.NOMINAL);
+//				amd.setRole(AttributeColumn.REGULAR);
+//				amd.setNumberOfMissingValues(new MDInteger(0));
+//			} else if (columnType.equals(AttributeTypes.BOOLEAN)) {
+//				attributes.add(AttributeFactory.createAttribute(columnName,
+//						Ontology.BINOMINAL));
+//				amd = new AttributeMetaData(columnName, Ontology.NOMINAL);
+//				amd.setRole(AttributeColumn.REGULAR);
+//				amd.setNumberOfMissingValues(new MDInteger(0));
+//			}
+//			metaData.addAttribute(amd);
+//		}
+//		// convert the list to array
+//		Attribute[] attribArray = new Attribute[attributes.size()];
+//		for (int i = 0; i < attributes.size(); i++) {
+//			attribArray[i] = attributes.get(i);
+//		}
+//		metaData.setNumberOfExamples(convertedLog.getRowCount());
+//
+//		this.attributes = attribArray;
+//		MemoryExampleTable memoryExampleTable = new MemoryExampleTable(
+//				attributes);
+//		return memoryExampleTable;
+//	}
+
+//	private ExampleSet fillTable(MemoryExampleTable table,
+//			TableModelXLog convertedLog) {
+//		DataRowFactory factory = new DataRowFactory(
+//				DataRowFactory.TYPE_DOUBLE_ARRAY, '.');
+//		// now add per row
+//		for (int i = 0; i < convertedLog.getRowCount(); i++) {
+//			// fill strings
+//			String[] strings = new String[convertedLog.getColumnCount()];
+//			for (int j = 0; j < convertedLog.getColumnCount(); j++) {
+//				strings[j] = convertedLog.getValueAt(i, j).toString();
+//			}
+//			DataRow dataRow = factory.create(strings, attributes);
+//			table.addDataRow(dataRow);
+//		}
+//		ExampleSet createExampleSet = table.createExampleSet();
+//		return createExampleSet;
+//	}
+
+//	private List<Double> getMinAndMaxValueColumn(TableModelXLog convertedLog,
+//			String nameCol) {
+//		double min = Double.MAX_VALUE;
+//		double max = Double.MIN_VALUE;
+//		int intCol = convertedLog.getNameForColumn(nameCol);
+//		for (int i = 0; i < convertedLog.getRowCount(); i++) {
+//			Object valueAt = convertedLog.getValueAt(i, intCol);
+//			if (valueAt instanceof String) {
+//				try {
+//					double parseDouble = Double.parseDouble((String) valueAt);
+//					min = parseDouble < min ? parseDouble : min;
+//					max = parseDouble > max ? parseDouble : max;
+//				} catch (Exception e) {
+//					// do nothing with it.
+//				}
+//			}
+//		}
+//		List<Double> doubleList = new ArrayList<Double>();
+//		doubleList.add(min);
+//		doubleList.add(max);
+//		return doubleList;
+//	}
+
+//	@SuppressWarnings("unused")
+//	protected Component createDefaultVisualizerComponent(Object renderable,
+//			IOContainer ioContainer) {
+//		XLogIOObject logioobject = (XLogIOObject) renderable;
+//		XLog xLog = logioobject.getArtifact();
+//		if (defaultComponent == null || defaultLog == null
+//				|| !(xLog.equals(defaultLog.get()))) {
+//			try {
+//
+//				PluginContext pluginContext = ProMPluginContextManager
+//						.instance().getContext();
+//
+//				LogDialogInitializer i = new LogDialogInitializer();
+//				SlickerOpenLogSettings o = new SlickerOpenLogSettings();
+//
+//				ClassLoader c = Thread.currentThread().getContextClassLoader();
+//
+//				defaultComponent = o.showLogVis(pluginContext, xLog);
+//				defaultLog = new WeakReference<XLog>(xLog);
+//			} catch (Exception e) {
+//				e.printStackTrace();
+//			}
+//		}
+//		return defaultComponent;
+//	}
+	
+	@SuppressWarnings("unused")
+	protected Component createDefaultVisualizerComponent(Object renderable,
+			IOContainer ioContainer) {
+		SLEXMMIOObject oobject = (SLEXMMIOObject) renderable;
+		SLEXMMStorageMetaModelImpl mm = oobject.getArtifact();
+		
+		if (defaultComponent == null || defaultMM == null
+				|| !(mm.equals(defaultMM.get()))) {
+			try {
+
+//				PluginContext pluginContext = ProMPluginContextManager
+//						.instance().getContext();
+
+//				LogDialogInitializer i = new LogDialogInitializer();
+//				SlickerOpenLogSettings o = new SlickerOpenLogSettings();
+
+//				ClassLoader c = Thread.currentThread().getContextClassLoader();
+
+//				defaultComponent = o.showLogVis(pluginContext, xLog);
+				defaultComponent = new MetaModelInspectorPanel(mm,false);
+				defaultMM = new WeakReference<SLEXMMStorageMetaModelImpl>(mm);
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+		}
+		return defaultComponent;
+	}
+
+//	protected Component createDottedChartVisualizerComponent(Object renderable,
+//			IOContainer ioContainer) {
+//		XLogIOObject logioobject = (XLogIOObject) renderable;
+//		XLog xLog = logioobject.getArtifact();
+//		if (dottedChartComponent == null || dottedLog == null
+//				|| !(xLog.equals(dottedLog.get()))) {
+//			try {
+//
+//				PluginContext pluginContext = ProMPluginContextManager
+//						.instance().getContext();
+//
+//				LogView result = new LogView(xLog);
+//				DottedChartInspector panel = LogProjectionPlugin
+//						.visualize(pluginContext, result);
+//				dottedChartComponent = (JComponent) panel;
+//				dottedLog = new WeakReference<XLog>(xLog);
+//			} catch (Exception e) {
+//				e.printStackTrace();
+//			}
+//		}
+//		return dottedChartComponent;
+//
+//	}
+
+	public Reportable createReportable(Object renderable,
+			IOContainer ioContainer, int desiredWidth, int desiredHeight) {
+		return new DefaultComponentRenderable(
+				getVisualizationComponent(renderable, ioContainer));
+	}
+}

--- a/RapidProM/src/org/rapidprom/ioobjectrenderers/SLEXMMIOObjectVisualizationType.java
+++ b/RapidProM/src/org/rapidprom/ioobjectrenderers/SLEXMMIOObjectVisualizationType.java
@@ -1,0 +1,20 @@
+package org.rapidprom.ioobjectrenderers;
+
+public enum SLEXMMIOObjectVisualizationType {
+
+//	EXAMPLE_SET("Example Set"),
+//	DOTTED_CHART("Dotted Chart"),
+//	DOTTED_CHART_L("Dotted Chart (Legacy)"),
+	DEFAULT("Default");
+	
+	private final String name;
+
+	private SLEXMMIOObjectVisualizationType(final String name) {
+		this.name = name;
+	}
+
+	@Override
+	public String toString() {
+		return name;
+	}
+};

--- a/RapidProM/src/org/rapidprom/ioobjectrenderers/SLEXMMIOSubSetObjectRenderer.java
+++ b/RapidProM/src/org/rapidprom/ioobjectrenderers/SLEXMMIOSubSetObjectRenderer.java
@@ -1,0 +1,66 @@
+package org.rapidprom.ioobjectrenderers;
+
+import java.awt.Component;
+import java.lang.ref.WeakReference;
+import java.util.EnumSet;
+import java.util.Set;
+
+import org.processmining.database.metamodel.dapoql.ui.components.DAPOQLResultsPanel;
+import org.processmining.openslex.metamodel.SLEXMMStorageMetaModelImpl;
+import org.rapidprom.ioobjectrenderers.abstr.AbstractMultipleVisualizersRenderer;
+import org.rapidprom.ioobjects.SLEXMMSubSetIOObject;
+import com.rapidminer.gui.renderer.DefaultComponentRenderable;
+import com.rapidminer.operator.IOContainer;
+import com.rapidminer.report.Reportable;
+
+public class SLEXMMIOSubSetObjectRenderer extends
+		AbstractMultipleVisualizersRenderer<SLEXMMIOSubSetObjectVisualizationType> {
+
+	public SLEXMMIOSubSetObjectRenderer() {
+		super(EnumSet.allOf(SLEXMMIOSubSetObjectVisualizationType.class),
+				"SLEXMM SubSet renderer");
+	}
+
+	private Component defaultComponent = null;
+	private WeakReference<Set<?>> defaultMM = null;
+
+	protected Component visualizeRendererOption(
+			SLEXMMIOSubSetObjectVisualizationType e, Object renderable,
+			IOContainer ioContainer) {
+
+		System.out.println("looking for renderer!");
+		Component result;
+		switch (e) {
+		default:
+		case DEFAULT:
+			result = createDefaultVisualizerComponent(renderable, ioContainer);
+			break;
+		}
+		return result;
+	}
+	
+	@SuppressWarnings("unused")
+	protected Component createDefaultVisualizerComponent(Object renderable,
+			IOContainer ioContainer) {
+		SLEXMMSubSetIOObject soobject = (SLEXMMSubSetIOObject) renderable;
+		SLEXMMStorageMetaModelImpl mm = soobject.getArtifact();
+		
+		if (defaultComponent == null || defaultMM == null
+				|| !(mm.equals(defaultMM.get()))) {
+			try {
+				defaultComponent = new DAPOQLResultsPanel(mm,soobject.getType(),soobject.getResults());
+				
+				defaultMM = new WeakReference<Set<?>>(soobject.getResults());
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+		}
+		return defaultComponent;
+	}
+
+	public Reportable createReportable(Object renderable,
+			IOContainer ioContainer, int desiredWidth, int desiredHeight) {
+		return new DefaultComponentRenderable(
+				getVisualizationComponent(renderable, ioContainer));
+	}
+}

--- a/RapidProM/src/org/rapidprom/ioobjectrenderers/SLEXMMIOSubSetObjectVisualizationType.java
+++ b/RapidProM/src/org/rapidprom/ioobjectrenderers/SLEXMMIOSubSetObjectVisualizationType.java
@@ -1,0 +1,21 @@
+package org.rapidprom.ioobjectrenderers;
+
+public enum SLEXMMIOSubSetObjectVisualizationType {
+ 
+//	EXAMPLE_SET("Example Set"),
+//	DOTTED_CHART("Dotted Chart"),
+//	DOTTED_CHART_L("Dotted Chart (Legacy)"),
+	DEFAULT("Default");
+	
+	private final String name;
+
+	private SLEXMMIOSubSetObjectVisualizationType(final String name) {
+		this.name = name;
+	}
+
+	@Override
+	public String toString() {
+		return name;
+	}
+	
+};

--- a/RapidProM/src/org/rapidprom/ioobjects/SLEXMMIOObject.java
+++ b/RapidProM/src/org/rapidprom/ioobjects/SLEXMMIOObject.java
@@ -1,0 +1,26 @@
+package org.rapidprom.ioobjects;
+
+import org.processmining.openslex.metamodel.SLEXMMStorageMetaModelImpl;
+import org.rapidprom.ioobjectrenderers.SLEXMMIOObjectVisualizationType;
+import org.rapidprom.ioobjects.abstr.AbstractRapidProMIOObject;
+
+public class SLEXMMIOObject extends AbstractRapidProMIOObject<SLEXMMStorageMetaModelImpl> {
+
+	private static final long serialVersionUID = -1323690731245887615L;
+	
+	private SLEXMMIOObjectVisualizationType visType;
+
+	public SLEXMMIOObject(SLEXMMStorageMetaModelImpl mm) {
+		super(mm,null);
+	}
+
+	public void setVisualizationType(SLEXMMIOObjectVisualizationType visType) {
+		this.visType = visType;
+		
+	}
+	public SLEXMMIOObjectVisualizationType getVisualizationType(){
+		return visType;
+	}
+
+	
+}

--- a/RapidProM/src/org/rapidprom/ioobjects/SLEXMMSubSetIOObject.java
+++ b/RapidProM/src/org/rapidprom/ioobjects/SLEXMMSubSetIOObject.java
@@ -1,0 +1,47 @@
+package org.rapidprom.ioobjects;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.processmining.openslex.metamodel.SLEXMMStorageMetaModelImpl;
+import org.rapidprom.ioobjectrenderers.SLEXMMIOSubSetObjectVisualizationType;
+import org.rapidprom.ioobjects.abstr.AbstractRapidProMIOObject;
+
+public class SLEXMMSubSetIOObject extends AbstractRapidProMIOObject<SLEXMMStorageMetaModelImpl> {
+
+	private static final long serialVersionUID = -1323690731245887615L;
+	
+	private SLEXMMIOSubSetObjectVisualizationType visType;
+	private Set<Object> results;
+	private HashMap<Object,HashSet<Integer>> mapResults;
+	private Class<?> type;
+
+	public SLEXMMSubSetIOObject(SLEXMMStorageMetaModelImpl mm, HashMap<Object,HashSet<Integer>> mapResults, Set<Object> results, Class<?> type) {
+		super(mm,null);
+		this.results = results;
+		this.mapResults = mapResults;
+		this.type = type;
+	}
+
+	public void setVisualizationType(SLEXMMIOSubSetObjectVisualizationType visType) {
+		this.visType = visType;
+		
+	}
+	public SLEXMMIOSubSetObjectVisualizationType getVisualizationType(){
+		return visType;
+	}
+	
+	public Set<Object> getResults() {
+		return results;
+	}
+
+	public HashMap<Object,HashSet<Integer>> getMapResults() {
+		return mapResults;
+	}
+	
+	public Class<?> getType() {
+		return type;
+	}
+	
+}

--- a/RapidProM/src/org/rapidprom/operators/conversion/ExampleSetToXLogConversionOperator.java
+++ b/RapidProM/src/org/rapidprom/operators/conversion/ExampleSetToXLogConversionOperator.java
@@ -19,6 +19,7 @@ import org.deckfour.xes.extension.std.XLifecycleExtension;
 import org.deckfour.xes.extension.std.XOrganizationalExtension;
 import org.deckfour.xes.extension.std.XTimeExtension;
 import org.deckfour.xes.factory.XFactory;
+import org.deckfour.xes.factory.XFactoryBufferedImpl;
 import org.deckfour.xes.factory.XFactoryRegistry;
 import org.deckfour.xes.model.XAttributeLiteral;
 import org.deckfour.xes.model.XAttributeMap;
@@ -28,6 +29,7 @@ import org.deckfour.xes.model.XTrace;
 import org.deckfour.xes.model.impl.XAttributeLiteralImpl;
 import org.deckfour.xes.model.impl.XAttributeMapImpl;
 import org.deckfour.xes.model.impl.XAttributeTimestampImpl;
+import org.processmining.xeslite.external.XFactoryExternalStore;
 //import org.processmining.models.xes.XEventPassageClassifier;
 import org.rapidprom.external.connectors.prom.ProMPluginContextManager;
 import org.rapidprom.ioobjects.XLogIOObject;
@@ -312,7 +314,8 @@ public class ExampleSetToXLogConversionOperator extends Operator {
 	}
 
 	private XLog constructLogByExampleSet(ExampleSet data) {
-		XFactory factory = XFactoryRegistry.instance().currentDefault();
+//		XFactory factory = XFactoryRegistry.instance().currentDefault();
+		XFactory factory = new XFactoryExternalStore.MapDBDiskImpl();
 
 		XLog log = createLog(factory, getParameterAsBoolean(
 				PARAMETER_KEY_INCLUDE_EVENT_LIFECYCLE_TRANSITION));

--- a/RapidProM/src/org/rapidprom/operators/experimental/DAPOQLangDialog.java
+++ b/RapidProM/src/org/rapidprom/operators/experimental/DAPOQLangDialog.java
@@ -1,0 +1,89 @@
+package org.rapidprom.operators.experimental;
+
+import javax.swing.JPanel;
+
+import com.rapidminer.gui.properties.PropertyDialog;
+import com.rapidminer.gui.wizards.ConfigurationListener;
+import com.rapidminer.parameter.ParameterType;
+
+import java.awt.BorderLayout;
+import java.awt.FlowLayout;
+import java.awt.event.ActionEvent;
+import javax.swing.JButton;
+import org.processmining.database.metamodel.dapoql.ui.components.DAPOQLQueryField;
+
+import com.rapidminer.gui.tools.ResourceAction;
+import com.rapidminer.parameter.Parameters;
+import com.rapidminer.parameter.UndefinedParameterError;
+
+
+public class DAPOQLangDialog extends PropertyDialog {
+	
+	private static final long serialVersionUID = -1695902812139200491L;
+
+	private boolean ok = false;
+
+	private final ConfigurationListener listener;
+
+	private DAPOQLQueryField qF = null;
+
+	public DAPOQLangDialog(ParameterType type, ConfigurationListener listener) {
+		super(type, "dapoql-query-editor");
+		this.listener = listener;
+
+		layoutDefault(createMainPanel(), createButtonPanel(), LARGE);
+	}
+
+	private JPanel createMainPanel() {
+		JPanel panel = new JPanel(new BorderLayout());
+		
+		qF = new DAPOQLQueryField();
+		String v = "";
+		try {
+			v = listener.getParameters().getParameter(DAPOQLangQueryOperator.PARAMETER_1);
+		} catch (UndefinedParameterError e) {
+			e.printStackTrace();
+		}
+		qF.setQuery(v);
+		panel.add(qF);
+		
+		return panel;
+	}
+	
+	private JPanel createButtonPanel() {
+		JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+		JButton okButton = new JButton(new ResourceAction("ok") {
+			
+			private static final long serialVersionUID = 5836090824300913876L;
+
+			public void actionPerformed(ActionEvent e) {
+				ok();
+			}
+		});
+		buttonPanel.add(okButton);
+		JButton cancelButton = makeCancelButton("cancel");
+		buttonPanel.add(cancelButton);
+		getRootPane().setDefaultButton(okButton);
+
+		JPanel bottomPanel = new JPanel(new BorderLayout());
+		bottomPanel.add(buttonPanel, BorderLayout.EAST);
+		return bottomPanel;
+	}
+
+	protected void ok() {
+		ok = true;
+		Parameters parameters = listener.getParameters();
+		parameters.setParameter(DAPOQLangQueryOperator.PARAMETER_1, qF.getQuery());
+		listener.setParameters(parameters);
+		dispose();
+	}
+
+	protected void cancel() {
+		ok = false;
+		dispose();
+	}
+
+	public boolean isOk() {
+		return ok;
+	}
+}

--- a/RapidProM/src/org/rapidprom/operators/experimental/DAPOQLangDialogCreator.java
+++ b/RapidProM/src/org/rapidprom/operators/experimental/DAPOQLangDialogCreator.java
@@ -1,0 +1,25 @@
+package org.rapidprom.operators.experimental;
+
+import com.rapidminer.gui.wizards.AbstractConfigurationWizardCreator;
+import com.rapidminer.gui.wizards.ConfigurationListener;
+import com.rapidminer.parameter.ParameterType;
+
+public class DAPOQLangDialogCreator extends AbstractConfigurationWizardCreator {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 8650517055293020063L;
+
+	@Override
+	public String getI18NKey() {
+		return "configure";
+	}
+
+	@Override
+	public void createConfigurationWizard(ParameterType type,
+			ConfigurationListener listener) {
+		(new DAPOQLangDialog(type, listener)).setVisible(true);
+	}
+
+}

--- a/RapidProM/src/org/rapidprom/operators/experimental/DAPOQLangQueryOperator.java
+++ b/RapidProM/src/org/rapidprom/operators/experimental/DAPOQLangQueryOperator.java
@@ -1,0 +1,123 @@
+package org.rapidprom.operators.experimental;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.processmining.database.metamodel.dapoql.DAPOQLRunner;
+import org.processmining.database.metamodel.dapoql.DAPOQLVariable;
+import org.processmining.database.metamodel.dapoql.QueryResult;
+import org.processmining.openslex.metamodel.SLEXMMStorageMetaModelImpl;
+import org.rapidprom.ioobjectrenderers.SLEXMMIOSubSetObjectVisualizationType;
+import org.rapidprom.ioobjects.SLEXMMIOObject;
+import org.rapidprom.ioobjects.SLEXMMSubSetIOObject;
+
+import com.rapidminer.gui.properties.ConfigureParameterOptimizationDialogCreator;
+import com.rapidminer.operator.Operator;
+import com.rapidminer.operator.OperatorChain;
+import com.rapidminer.operator.OperatorDescription;
+import com.rapidminer.operator.OperatorException;
+import com.rapidminer.operator.ports.InputPort;
+import com.rapidminer.operator.ports.InputPortExtender;
+import com.rapidminer.operator.ports.OutputPort;
+import com.rapidminer.operator.ports.metadata.GenerateNewMDRule;
+import com.rapidminer.operator.ports.metadata.MetaData;
+import com.rapidminer.parameter.ParameterType;
+import com.rapidminer.parameter.ParameterTypeConfiguration;
+import com.rapidminer.parameter.ParameterTypeInnerOperator;
+import com.rapidminer.parameter.ParameterTypeList;
+import com.rapidminer.parameter.ParameterTypeParameterValue;
+import com.rapidminer.parameter.ParameterTypeString;
+import com.rapidminer.parameter.ParameterTypeTupel;
+import com.rapidminer.tools.LogService;
+
+public class DAPOQLangQueryOperator extends Operator {
+
+	public static final String PARAMETER_1 = "Query";
+
+	private InputPort inputMM = getInputPorts().createPort(
+			"OpenSLEX Meta Model", SLEXMMIOObject.class);
+
+	private final InputPortExtender inputMMSet = new InputPortExtender(
+			"OpenSLEX Meta Model SubSet", getInputPorts(), new MetaData(SLEXMMSubSetIOObject.class), 0);
+			
+	private OutputPort outputMMSet = getOutputPorts().createPort(
+			"OpenSLEX Meta Model SubSet");
+	
+	private MetaData outputMD = new MetaData(SLEXMMSubSetIOObject.class);
+	
+	public DAPOQLangQueryOperator(OperatorDescription description) {
+		super(description);
+		getTransformer().addRule(new GenerateNewMDRule(outputMMSet, SLEXMMSubSetIOObject.class));
+		//outputMMSet.deliverMD(outputMD);
+		inputMMSet.start();
+	}
+	
+	@Override
+	public void doWork() throws OperatorException {
+		Logger logger = LogService.getRoot();
+		logger.log(Level.INFO, "Start: dapoq-lang query");
+		long time = System.currentTimeMillis();
+		MetaData md = inputMM.getMetaData();
+		
+		SLEXMMIOObject mmIO = inputMM.getData(SLEXMMIOObject.class);
+		SLEXMMStorageMetaModelImpl slxmm = mmIO.getArtifact();
+		
+		Set<DAPOQLVariable> vars = new HashSet<>();
+
+		List<SLEXMMSubSetIOObject> listInpt = inputMMSet.getData(SLEXMMSubSetIOObject.class, true);
+		
+		int i = 1;
+		for (SLEXMMSubSetIOObject item : listInpt) {
+			DAPOQLVariable v = new DAPOQLVariable("_v"+i, item.getType(), item.getMapResults());
+			vars.add(v);
+			i++;
+		}
+		
+		String query = getParameterAsString(PARAMETER_1);
+
+		boolean failed = true;
+		QueryResult qr = null;
+		DAPOQLRunner dapoqlr = new DAPOQLRunner();
+		String msgFailure = "";
+		try {
+			qr = dapoqlr.executeQuery(slxmm, query, vars);
+			failed = false;
+		} catch (Exception e) {
+			failed = true;
+			e.printStackTrace();
+			msgFailure = e.toString();
+		}
+		
+		if (!failed) {
+			SLEXMMSubSetIOObject slxmmSubSetIOObject = new SLEXMMSubSetIOObject(slxmm,qr.mapResult,qr.result,qr.type);
+			slxmmSubSetIOObject
+					.setVisualizationType(SLEXMMIOSubSetObjectVisualizationType.DEFAULT);
+			outputMMSet.deliverMD(outputMD);
+			outputMMSet.deliver(slxmmSubSetIOObject);
+		} else {
+			outputMMSet.deliverMD(outputMD);
+			outputMMSet.deliver(null);
+			throw new OperatorException(msgFailure);
+		}
+		logger.log(Level.INFO,
+				"End: dapoq-lang query ("
+						+ (System.currentTimeMillis() - time) / 1000 + " sec)");
+	}
+
+	public List<ParameterType> getParameterTypes() {
+		List<ParameterType> parameterTypes = super.getParameterTypes();
+
+		ParameterType queryType = new ParameterTypeString(PARAMETER_1,PARAMETER_1,"",true);
+		parameterTypes.add(queryType);
+		ParameterType type =
+				new ParameterTypeConfiguration(DAPOQLangDialogCreator.class, this);
+        type.setExpert(false);
+        parameterTypes.add(type);
+		
+		return parameterTypes;
+	}
+	
+}

--- a/RapidProM/src/org/rapidprom/operators/experimental/DataModelMM.java
+++ b/RapidProM/src/org/rapidprom/operators/experimental/DataModelMM.java
@@ -1,0 +1,269 @@
+package org.rapidprom.operators.experimental;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+
+import org.processmining.openslex.metamodel.SLEXMMAttribute;
+import org.processmining.openslex.metamodel.SLEXMMClass;
+import org.processmining.openslex.metamodel.SLEXMMDataModel;
+import org.processmining.openslex.metamodel.SLEXMMRelationship;
+import org.processmining.openslex.metamodel.SLEXMMStorageMetaModel;
+
+import com.rapidminer.example.Attribute;
+import com.rapidminer.example.Attributes;
+import com.rapidminer.example.Example;
+import com.rapidminer.example.ExampleSet;
+
+public class DataModelMM {
+
+	public static final String AT_DATAMODEL = "datamodel";
+	public static final String AT_CLASS = "class";
+	public static final String AT_ATNAME = "attribute_name";
+	public static final String AT_RS_NAME = "relationship_name";
+	public static final String AT_RS_CLASS_SOURCE = "class_source";
+	public static final String AT_RS_CLASS_TARGET = "class_target";
+	public static final String AT_RS_ATNAME_SOURCE = "attribute_source";
+	public static final String AT_RS_ATNAME_TARGET = "attribute_target";
+	
+	private HashMap<String,SLEXMMDataModel> slxdmmap = new HashMap<>();
+	
+	private HashMap<String, // datamodel
+		HashMap<String, // class
+			HashSet<String> // attribute names
+		>
+	> dmmap = new HashMap<>();
+	
+	private HashMap<String, // datamodel
+		HashMap<String, // class
+			SLEXMMClass // slx Class
+		>
+	> slxclassmap = new HashMap<>();
+	
+	private HashMap<Integer, // slx Class Id
+		HashMap<String, // att name
+			SLEXMMAttribute // slx Attribute
+		>
+	> attsPerClass = new HashMap<>();
+	
+	private HashMap<Integer, // slx Class Id
+		ArrayList<DataModelMMKey> // List of Keys
+	> keysPerClass = new HashMap<>();
+	
+	private HashMap<Integer, // slx Class Id
+		DataModelMMKey // PK Key
+	> pkPerClass = new HashMap<>();
+	
+	private HashMap<Integer, // slx Class Id
+		ArrayList<DataModelMMKey> // List of FK Keys
+	> fksPerClass = new HashMap<>();
+	
+	private SLEXMMStorageMetaModel mm = null;
+	
+	public DataModelMM(SLEXMMStorageMetaModel mm, ExampleSet esclasses, ExampleSet eskeys) throws Exception {
+		this.mm = mm;
+		init(esclasses, eskeys);
+	}
+	
+	private void init(ExampleSet esclasses, ExampleSet eskeys) throws Exception {
+		parseClasses(esclasses);
+		parseKeys(eskeys);
+	}
+	
+	public SLEXMMClass getClassForName(String datamodel, String name) {
+		if (slxclassmap.containsKey(datamodel)) {
+			if (slxclassmap.get(datamodel).containsKey(name)) {
+				return slxclassmap.get(datamodel).get(name);
+			}
+		}
+		return null;
+	}
+	
+	public SLEXMMAttribute getAttributeForName(SLEXMMClass c, String name) {
+		if (attsPerClass.containsKey(c.getId())) {
+			return attsPerClass.get(c.getId()).get(name);
+		}
+		return null;
+	}
+	
+	public List<DataModelMMKey> getKeysForClass(SLEXMMClass c) {
+		if (keysPerClass.containsKey(c.getId())) {
+			return keysPerClass.get(c.getId());
+		}
+		return null;
+	}
+	
+	public DataModelMMKey getPKForClass(SLEXMMClass c) {
+		if (pkPerClass.containsKey(c.getId())) {
+			return pkPerClass.get(c.getId());
+		}
+		return null;
+	}
+	
+	public List<DataModelMMKey> getFKsForClass(SLEXMMClass c) {
+		if (fksPerClass.containsKey(c.getId())) {
+			return fksPerClass.get(c.getId());
+		}
+		return null;
+	}
+	
+	private void parseKeys(ExampleSet eskeys) throws Exception {
+		
+		HashMap<String, // datamodel
+			HashMap<String, // key name
+				DataModelMMKey // key
+			>
+		> kymap = new HashMap<>();
+	
+//		HashMap<String, // datamodel
+//			HashMap<String, // source class
+//				HashSet<DataModelMMKey> // set of keys
+//			>
+//		> kyPerSourceMap = new HashMap<>();
+		
+		Attributes ats = eskeys.getAttributes();
+		Attribute kydm = ats.get(AT_DATAMODEL, false);
+		Attribute kynm = ats.get(AT_RS_NAME, false);
+		Attribute kycls = ats.get(AT_RS_CLASS_SOURCE, false);
+		Attribute kyclt = ats.get(AT_RS_CLASS_TARGET, false);
+		Attribute kyats = ats.get(AT_RS_ATNAME_SOURCE, false);
+		Attribute kyatt = ats.get(AT_RS_ATNAME_TARGET, false);
+		
+		if (kydm == null || kynm == null || kycls == null ||
+				kyclt == null || kyats == null || kyatt == null) {
+			throw new Exception("Required attributes not present");
+		}
+		
+		Iterator<Example> it = eskeys.iterator();
+		
+		while (it.hasNext()) {
+			
+			Example e = it.next();
+			String str_dm = e.getValueAsString(kydm);
+			String str_nm = e.getValueAsString(kynm);
+			String str_cls = e.getValueAsString(kycls);
+			String str_clt = e.getValueAsString(kyclt);
+			String str_ats = e.getValueAsString(kyats);
+			String str_att = e.getValueAsString(kyatt);
+			
+			if (!kymap.containsKey(str_dm)) {
+				kymap.put(str_dm, new HashMap<String,DataModelMMKey>());
+			}
+			HashMap<String, DataModelMMKey> rsmap = kymap.get(str_dm);
+						
+			if (!rsmap.containsKey(str_nm)) {
+				
+				Integer sourceClassId = null;
+				
+				if (slxclassmap.containsKey(str_dm)) {
+					if (slxclassmap.get(str_dm).containsKey(str_cls)) {
+						sourceClassId = slxclassmap.get(str_dm).get(str_cls).getId();
+					}
+				}
+				
+				Integer targetClassId = null;
+				
+				if (slxclassmap.containsKey(str_dm)) {
+					if (slxclassmap.get(str_dm).containsKey(str_clt)) {
+						targetClassId = slxclassmap.get(str_dm).get(str_clt).getId();
+					}
+				}
+				
+				if (targetClassId == null) {
+					targetClassId = -1;
+				}
+				
+				if (sourceClassId != null) {
+					SLEXMMRelationship slxrs = mm.createRelationship(str_nm,
+							sourceClassId, targetClassId);
+
+					DataModelMMKey k = new DataModelMMKey(str_nm, str_cls,
+							str_clt, slxrs.getId());
+					rsmap.put(str_nm, k);
+
+					if (!keysPerClass.containsKey(sourceClassId)) {
+						keysPerClass.put(sourceClassId,
+								new ArrayList<DataModelMMKey>());
+					}
+					keysPerClass.get(sourceClassId).add(k);
+
+					if (targetClassId == -1) {
+						pkPerClass.put(sourceClassId, k);
+					} else {
+						if (!fksPerClass.containsKey(sourceClassId)) {
+							fksPerClass.put(sourceClassId,
+									new ArrayList<DataModelMMKey>());
+						}
+						fksPerClass.get(sourceClassId).add(k);
+					}
+				} else {
+					throw new Exception(
+							"Source class name: '" + str_cls + "' not found");
+				}
+			}
+			
+			DataModelMMKey k = rsmap.get(str_nm);
+			k.getAttributesMap().put(str_ats,str_att);
+			
+//			if (!kyPerSourceMap.containsKey(str_dm)) {
+//				kyPerSourceMap.put(str_dm, new HashMap<String,HashSet<DataModelMMKey>>());
+//			}
+//			HashMap<String,HashSet<DataModelMMKey>> sclmap = kyPerSourceMap.get(str_dm);
+//			
+//			if (!sclmap.containsKey(str_cls)) {
+//				sclmap.put(str_cls, new HashSet<DataModelMMKey>());
+//			}
+//			HashSet<DataModelMMKey> kset = sclmap.get(str_cls);
+//			kset.add(k);
+		}
+		
+		
+	}
+
+	private void parseClasses(
+			ExampleSet esclasses) throws Exception {
+
+		Attributes ats = esclasses.getAttributes();
+		Attribute atdm = ats.get(AT_DATAMODEL, false);
+		Attribute atcl = ats.get(AT_CLASS, false);
+		Attribute atnm = ats.get(AT_ATNAME, false);
+
+		if (atdm == null || atcl == null || atnm == null) {
+			throw new Exception("Required attributes not present");
+		}
+
+		Iterator<Example> it = esclasses.iterator();
+
+		while (it.hasNext()) {
+			Example e = it.next();
+			String str_dm = e.getValueAsString(atdm);
+			String str_cl = e.getValueAsString(atcl);
+			String str_at = e.getValueAsString(atnm);
+
+			if (!dmmap.containsKey(str_dm)) {
+				dmmap.put(str_dm, new HashMap<String, HashSet<String>>());
+				slxclassmap.put(str_dm, new HashMap<String,SLEXMMClass>());
+				slxdmmap.put(str_dm, mm.createDataModel(str_dm));
+			}
+			HashMap<String, HashSet<String>> clmap = dmmap.get(str_dm);
+			SLEXMMDataModel slxdm = slxdmmap.get(str_dm);
+
+			if (!clmap.containsKey(str_cl)) {
+				clmap.put(str_cl, new HashSet<String>());
+				SLEXMMClass slxcl = mm.createClass(slxdm.getId(), str_cl);
+				slxclassmap.get(str_dm).put(str_cl,slxcl);
+				attsPerClass.put(slxcl.getId(), new HashMap<String,SLEXMMAttribute>());
+			}
+			SLEXMMClass slxcl = slxclassmap.get(str_dm).get(str_cl);
+
+			HashSet<String> atset = clmap.get(str_cl);
+			atset.add(str_at);
+			SLEXMMAttribute at = mm.createAttribute(slxcl.getId(), str_at);
+			attsPerClass.get(slxcl.getId()).put(str_at, at);
+		}
+
+	}
+	
+}

--- a/RapidProM/src/org/rapidprom/operators/experimental/DataModelMMKey.java
+++ b/RapidProM/src/org/rapidprom/operators/experimental/DataModelMMKey.java
@@ -1,0 +1,39 @@
+package org.rapidprom.operators.experimental;
+
+import java.util.HashMap;
+
+public class DataModelMMKey {
+	private String name;
+	private String source_class;
+	private String target_class;
+	private HashMap<String,String> attMap;
+	private int relationshipId = -1;
+	
+	public DataModelMMKey(String name, String source_class, String target_class, int relationshipId) {
+		this.name = name;
+		this.source_class = source_class;
+		this.target_class = target_class;
+		this.attMap = new HashMap<>();
+		this.relationshipId = relationshipId;
+	}
+	
+	public String getName() {
+		return name;
+	}
+	
+	public String getSourceClass() {
+		return source_class;
+	}
+	
+	public String getTargetClass() {
+		return target_class;
+	}
+	
+	public HashMap<String,String> getAttributesMap() {
+		return attMap;
+	}
+	
+	public int getRelationshipId() {
+		return relationshipId;
+	}
+}

--- a/RapidProM/src/org/rapidprom/operators/experimental/GenerateSLEXMMOperator.java
+++ b/RapidProM/src/org/rapidprom/operators/experimental/GenerateSLEXMMOperator.java
@@ -1,0 +1,885 @@
+package org.rapidprom.operators.experimental;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.io.File;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+
+import org.processmining.openslex.metamodel.SLEXMMActivity;
+import org.processmining.openslex.metamodel.SLEXMMActivityInstance;
+import org.processmining.openslex.metamodel.SLEXMMAttribute;
+import org.processmining.openslex.metamodel.SLEXMMAttributeValue;
+import org.processmining.openslex.metamodel.SLEXMMCase;
+import org.processmining.openslex.metamodel.SLEXMMClass;
+import org.processmining.openslex.metamodel.SLEXMMEvent;
+import org.processmining.openslex.metamodel.SLEXMMEventAttribute;
+import org.processmining.openslex.metamodel.SLEXMMLog;
+import org.processmining.openslex.metamodel.SLEXMMObject;
+import org.processmining.openslex.metamodel.SLEXMMObjectVersion;
+import org.processmining.openslex.metamodel.SLEXMMProcess;
+import org.processmining.openslex.metamodel.SLEXMMRelation;
+import org.processmining.openslex.metamodel.SLEXMMStorageMetaModel;
+import org.processmining.openslex.metamodel.SLEXMMStorageMetaModelImpl;
+import org.rapidprom.ioobjectrenderers.SLEXMMIOObjectVisualizationType;
+import org.rapidprom.ioobjects.SLEXMMIOObject;
+
+import com.google.gwt.dev.util.collect.HashSet;
+import com.rapidminer.example.Attribute;
+import com.rapidminer.example.Attributes;
+import com.rapidminer.example.Example;
+import com.rapidminer.example.ExampleSet;
+import com.rapidminer.example.table.AttributeFactory;
+import com.rapidminer.example.table.NumericalAttribute;
+import com.rapidminer.operator.Annotations;
+import com.rapidminer.operator.IOObjectCollection;
+import com.rapidminer.operator.Operator;
+import com.rapidminer.operator.OperatorDescription;
+import com.rapidminer.operator.OperatorException;
+import com.rapidminer.operator.ports.InputPort;
+import com.rapidminer.operator.ports.OutputPort;
+import com.rapidminer.operator.ports.metadata.GenerateNewMDRule;
+import com.rapidminer.operator.ports.metadata.MetaData;
+import com.rapidminer.operator.preprocessing.filter.attributes.NumericalAttributeFilter;
+import com.rapidminer.parameter.ParameterType;
+import com.rapidminer.parameter.ParameterTypeFile;
+import com.rapidminer.tools.LogService;
+
+public class GenerateSLEXMMOperator extends Operator {
+
+	private final static String[] SUPPORTED_FILE_FORMATS = new String[] { "slexmm" };
+	private final static String PARAMETER_KEY = "file";
+	private final static String PARAMETER_DESC = "Select where to save the generated Meta Model.";
+	
+	private final static String EV_EXSET_ANNOTATION_FILE_NAME = "file_name";
+	private final static String EV_EXSET_ANNOTATION_TIMESTAMP = "timestamp";
+	private final static String EV_EXSET_ANNOTATION_TIMESTAMP_FORMAT = "timestamp_format";
+	private final static String EV_EXSET_ANNOTATION_ACTIVITY = "activity";
+	private final static String EV_EXSET_ANNOTATION_ACTIVITY_INSTANCE = "activity_instance";
+	private final static String EV_EXSET_ANNOTATION_LIFECYCLE = "lifecycle";
+	private final static String EV_EXSET_ANNOTATION_RESOURCE = "resource";
+	
+	private final static String VER_EXSET_ANNOTATION_FILE_NAME = "file_name";
+	private final static String VER_EXSET_ANNOTATION_DATAMODEL_NAME = "datamodel_name";
+	private final static String VER_EXSET_ANNOTATION_CLASS_NAME = "class_name";
+	private final static String VER_EXSET_ANNOTATION_START_TIMESTAMP = "start_timestamp";
+	private final static String VER_EXSET_ANNOTATION_END_TIMESTAMP = "end_timestamp";
+	private final static String VER_EXSET_ANNOTATION_TIMESTAMP_FORMAT = "timestamp_format";
+	
+	private final static String EV_TO_VER_MAPPING_EVID_FIELD = "eventId";
+	private final static String EV_TO_VER_MAPPING_VERID_FIELD = "versionId";
+	private final static String EV_TO_VER_MAPPING_LABEL_FIELD = "label";
+	
+	private final static String LOGS_PROC_ID_FIELD = "processId";
+	private final static String LOGS_LOG_ID_FIELD = "logId";
+	private final static String LOGS_TRACE_ID_FIELD = "traceId";
+	private final static String LOGS_EVENT_ID_FIELD = "eventId";
+
+	private InputPort inputDMClasses = getInputPorts().createPort (
+			"Classes definition", ExampleSet.class);
+	
+	private InputPort inputDMKeys = getInputPorts().createPort(
+			"Keys definition", ExampleSet.class);
+
+	private InputPort inputVersionsCollection = getInputPorts().createPort(
+			"Versions collection", new IOObjectCollection<ExampleSet>().getClass());
+
+	private InputPort inputEventsCollection = getInputPorts().createPort(
+			"Events collection", new IOObjectCollection<ExampleSet>().getClass());
+	
+	private InputPort inputEventsToObjectV = getInputPorts().createPort(
+			"EvToObjV mapping", ExampleSet.class);
+	
+	private InputPort inputLogs = getInputPorts().createPort(
+			"Logs table", ExampleSet.class);
+	
+	private OutputPort outputMM = getOutputPorts().createPort(
+			"OpenSLEX Meta Model");
+	
+	private MetaData outputMD = new MetaData(SLEXMMIOObject.class);
+	
+	public GenerateSLEXMMOperator(OperatorDescription description) {
+		super(description);
+		getTransformer().addRule(new GenerateNewMDRule(outputMM, SLEXMMIOObject.class));
+		//outputMMSet.deliverMD(outputMD);
+	}
+	
+	@Override
+	public void doWork() throws OperatorException {		
+		Logger logger = LogService.getRoot();
+		logger.log(Level.INFO, "Start: Generate MM");
+		long time = System.currentTimeMillis();
+		
+		boolean failed = true;
+		String msgFailure = "Generation of MM failed";
+		SLEXMMStorageMetaModelImpl mm = null;
+		//MetaData md = inputMM.getMetaData();
+		
+		//SLEXMMIOObject mmIO = inputMM.getData(SLEXMMIOObject.class);
+		//SLEXMMStorageMetaModelImpl slxmm = mmIO.getArtifact();
+		
+//		String query = getParameterAsString(PARAMETER_1);
+
+		ExampleSet exsDMClasses = inputDMClasses.getData(ExampleSet.class);
+		ExampleSet exsDMKeys = inputDMKeys.getData(ExampleSet.class);
+		
+		try {			
+			String fileName = getParameter(PARAMETER_KEY);
+			if (fileName == null) {
+				throw new Exception("File parameter not set");
+			} else {
+				File f = new File(fileName);
+				f.delete();
+				f.createNewFile();
+				mm = new SLEXMMStorageMetaModelImpl(f.getParent(), f.getName());
+				mm.setAutoCommit(false);
+			}
+			
+			DataModelMM dmm = new DataModelMM(mm,exsDMClasses,exsDMKeys);
+			
+			HashMap<Double,Integer> evIdMap = new HashMap<>();
+			HashMap<Double,Integer> verIdMap = new HashMap<>();
+			HashMap<Integer,SLEXMMActivityInstance> evToAIMap = new HashMap<>();
+			
+			mm.commit();
+			
+			if (inputEventsCollection.isConnected()) {
+				IOObjectCollection<ExampleSet> evCol = inputEventsCollection.getData(IOObjectCollection.class);
+				if (evCol != null) {
+					importEvents(evCol,mm,evIdMap,evToAIMap);
+				}
+			}
+			
+			if (inputVersionsCollection.isConnected()) {
+				IOObjectCollection<ExampleSet> verCol = inputVersionsCollection.getData(IOObjectCollection.class);
+				if (verCol != null) {
+					importVersions(verCol,dmm,mm,verIdMap);
+				}
+			}
+			
+			if (inputEventsToObjectV.isConnected()) {
+				ExampleSet exsEvToObjV = inputEventsToObjectV.getData(ExampleSet.class);
+				if (exsEvToObjV != null) {
+					importMappingEvsToObjVersions(exsEvToObjV,mm,evIdMap,verIdMap);
+				}
+			}
+			
+			if (inputLogs.isConnected()) {
+				ExampleSet exsLogs = inputLogs.getData(ExampleSet.class);
+				if (exsLogs != null) {
+					importLogs(exsLogs,mm,evIdMap,evToAIMap);
+				}
+			}
+			
+			mm.commit();
+			failed = false;
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new OperatorException(e.getMessage());
+		}
+		
+		if (!failed) {
+			SLEXMMIOObject slxmmIOObject = new SLEXMMIOObject(mm);
+			slxmmIOObject
+					.setVisualizationType(SLEXMMIOObjectVisualizationType.DEFAULT);
+			outputMM.deliverMD(outputMD);
+			outputMM.deliver(slxmmIOObject);
+		} else {
+			outputMM.deliverMD(outputMD);
+			outputMM.deliver(null);
+			throw new OperatorException(msgFailure);
+		}
+		logger.log(Level.INFO,
+				"End: Generate MM ("
+						+ (System.currentTimeMillis() - time) / 1000 + " sec)");
+	}
+
+	private void importLogs(ExampleSet exsLogs, SLEXMMStorageMetaModel mm,
+			HashMap<Double,Integer> evIdMap,
+			HashMap<Integer,SLEXMMActivityInstance> eventsToAIMap) throws Exception {
+		
+		HashMap<String,Integer> procsMap = new HashMap<>();
+		HashMap<String,Integer> logsMap = new HashMap<>();
+		HashMap<String,SLEXMMCase> tracesMap = new HashMap<>();
+		HashMap<Integer,HashSet<Integer>> actsToProc = new HashMap<>();
+		
+		Attributes atts = exsLogs.getAttributes();
+		Attribute procIdAt = atts.get(LOGS_PROC_ID_FIELD, false);
+		Attribute logIdAt = atts.get(LOGS_LOG_ID_FIELD, false);
+		Attribute traceIdAt = atts.get(LOGS_TRACE_ID_FIELD, false);
+		Attribute eventIdAt = atts.get(LOGS_EVENT_ID_FIELD, false);
+		
+		long i = 0;
+		
+		if (procIdAt != null && logIdAt != null && traceIdAt != null && 
+				eventIdAt != null) {
+			for (Example example : exsLogs) {
+				
+				String procName = example.getValueAsString(procIdAt);
+				String logName = example.getValueAsString(logIdAt);
+				String traceName = example.getValueAsString(traceIdAt);
+				double evId = example.getNumericalValue(eventIdAt);
+				
+				Integer evMMId = evIdMap.get(evId);
+				
+				if (evMMId != null) {
+					Integer procId = procsMap.get(procName);
+					
+					if (procId == null) {
+						SLEXMMProcess proc = mm.createProcess(procName);
+						procId = proc.getId();
+						procsMap.put(procName, procId);
+						i++;
+					}
+					
+					Integer logId = logsMap.get(logName);
+					
+					if (logId == null) {
+						SLEXMMLog log = mm.createLog(procId, logName);
+						logId = log.getId();
+						logsMap.put(logName, logId);
+						i++;
+					}
+					
+					SLEXMMCase trace = tracesMap.get(traceName);
+					
+					if (trace == null) {
+						trace = mm.createCase(traceName);
+						mm.addCaseToLog(logId, trace.getId());
+						tracesMap.put(traceName, trace);
+						i++;
+					}
+					
+					SLEXMMActivityInstance aiMM = eventsToAIMap.get(evMMId);
+					
+					if (aiMM != null) {
+						try {
+							trace.add(aiMM.getId());
+							HashSet<Integer> procsSet = actsToProc.get(aiMM.getActivityId());
+							if (procsSet == null) {
+								procsSet = new HashSet<Integer>();
+								actsToProc.put(aiMM.getActivityId(),procsSet);
+							}
+							if (!procsSet.contains(procId)) {
+								mm.addActivityToProcess(procId, aiMM.getActivityId());
+								procsSet.add(procId);
+								i++;
+							}
+						} catch (Exception e) {
+							e.printStackTrace();
+						}
+					}
+										
+					i++;
+				}
+				
+				if (i >= 100) {
+					mm.commit();
+					i = 0L;
+				} else {
+					i++;
+				}
+			}
+		} else {
+			throw new Exception("Attributes missing in logs table");
+		}
+	}
+	
+	private void importMappingEvsToObjVersions(ExampleSet exsEvToObjV, SLEXMMStorageMetaModel mm,
+			HashMap<Double,Integer> evIdMap, HashMap<Double,Integer> verIdMap) throws Exception {
+		
+		Attributes atts = exsEvToObjV.getAttributes();
+		Attribute evIdAt = atts.get(EV_TO_VER_MAPPING_EVID_FIELD, false);
+		Attribute verIdAt = atts.get(EV_TO_VER_MAPPING_VERID_FIELD, false);
+		Attribute labelAt = atts.get(EV_TO_VER_MAPPING_LABEL_FIELD, false);
+		
+		long i = 0;
+		
+		if (evIdAt != null && verIdAt != null) {
+			for (Example example : exsEvToObjV) {
+				
+				double evId = example.getNumericalValue(evIdAt);
+				double verId = example.getNumericalValue(verIdAt);
+				
+				String label = "";
+				if (labelAt != null) {
+					label = example.getValueAsString(labelAt);
+				}
+				
+				Integer evMMId = evIdMap.get(evId);
+				Integer verMMId = verIdMap.get(verId);
+				
+				if (evMMId != null && verMMId != null) {
+					try {
+						mm.addEventToObjectVersion(verMMId, evMMId, label);
+						i++;
+					} catch (Exception e) {
+						e.printStackTrace();
+					}
+				}
+				
+				if (i >= 100) {
+					mm.commit();
+					i = 0L;
+				} else {
+					i++;
+				}
+			}
+		} else {
+			throw new Exception("Attributes missing for mapping events to versions");
+		}
+	}
+	
+	private void computeEndTimestampsVersions(ExampleSet verExSet, List<Attribute> pkListAtts,
+			SLEXMMClass clmm, SimpleDateFormat dateFormatter,
+			Attribute startTimestampAtt, Attribute endTimestampAtt,
+			HashMap<Double,Long> startTimePerVersion, HashMap<Double,Long> endTimePerVersion) {
+		
+		HashMap<Integer,HashMap<String,ArrayList<Double>>> versionsPerClassMap = new HashMap<>();
+		
+		for (Example example : verExSet) {
+			try {
+				
+				StringBuilder objIdStr = new StringBuilder();
+				for (Attribute at: pkListAtts) {
+					objIdStr.append(example.getValueAsString(at));
+					objIdStr.append('#');
+				}
+				
+				long startTimestampL = -2L;
+				if (startTimestampAtt != null) {
+					startTimestampL = dateFormatter
+							.parse(example.getValueAsString(startTimestampAtt))
+							.getTime();
+				}
+				
+				long endTimestampL = -1L;
+				if (endTimestampAtt != null) {
+					endTimestampL = dateFormatter
+							.parse(example.getValueAsString(endTimestampAtt))
+							.getTime();
+				}
+				
+				startTimePerVersion.put(example.getId(), startTimestampL);
+				endTimePerVersion.put(example.getId(), endTimestampL);
+				
+				if (!versionsPerClassMap.containsKey(clmm.getId())) {
+					versionsPerClassMap.put(clmm.getId(), new HashMap<String,ArrayList<Double>>());
+				}
+				HashMap<String,ArrayList<Double>> objsClassMap = versionsPerClassMap.get(clmm.getId());
+				
+				if (!objsClassMap.containsKey(objIdStr.toString())) {
+					objsClassMap.put(objIdStr.toString(), new ArrayList<Double>());
+				}
+				
+				ArrayList<Double> versOfObj = objsClassMap.get(objIdStr.toString());
+				if (endTimestampAtt == null) {
+					if (versOfObj.size() > 0) {
+						Double lastv = versOfObj.get(versOfObj.size() - 1);
+						endTimePerVersion.put(lastv, startTimestampL);
+					}
+				}
+				versOfObj.add(example.getId());
+				
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+		}
+	}
+	
+	private void parseRows(ExampleSet verExSet, List<Attribute> pkListAtts,
+			HashMap<String,Integer> objMap, Long i, SLEXMMClass clmm,
+			SLEXMMStorageMetaModel mm,
+			HashMap<Integer,HashMap<String,ArrayList<Integer>>> versionsPerClassMap,
+			HashMap<Double,Long> startTimePerExample, HashMap<Integer,Long> startTimePerVersion,
+			HashMap<Double,Long> endTimePerExample, HashMap<Integer,Long> endTimePerVersion,
+			HashMap<Attribute,SLEXMMAttribute> attsToVerAttsMap,
+			HashMap<Integer,HashMap<String,HashMap<Integer,HashMap<Integer,String>>>> relsPerClassMap,
+			List<DataModelMMKey> fks,Attributes atts, HashMap<Double,Integer> verIdMap) {
+		
+		for (Example example : verExSet) {
+			try {
+				
+				Integer objId = null;
+				StringBuilder objIdStr = new StringBuilder();
+				for (Attribute at: pkListAtts) {
+					objIdStr.append(example.getValueAsString(at));
+					objIdStr.append('#');
+				}
+				
+				objId = objMap.get(objIdStr.toString());
+				if (objId == null) {
+					SLEXMMObject objmm = mm.createObject(clmm.getId());
+					objId = objmm.getId();
+					objMap.put(objIdStr.toString(),objId);
+				}
+				
+				long startTimestampL = startTimePerExample.get(example.getId());
+				
+				long endTimestampL = endTimePerExample.get(example.getId());
+
+				SLEXMMObjectVersion ver = mm.createObjectVersion(objId,
+						startTimestampL, endTimestampL);
+				verIdMap.put(example.getId(), ver.getId());
+				
+				startTimePerVersion.put(ver.getId(), startTimestampL);
+				endTimePerVersion.put(ver.getId(), endTimestampL);
+				
+				if (!versionsPerClassMap.containsKey(clmm.getId())) {
+					versionsPerClassMap.put(clmm.getId(), new HashMap<String,ArrayList<Integer>>());
+				}
+				HashMap<String,ArrayList<Integer>> objsClassMap = versionsPerClassMap.get(clmm.getId());
+				
+				if (!objsClassMap.containsKey(objIdStr.toString())) {
+					objsClassMap.put(objIdStr.toString(), new ArrayList<Integer>());
+				}
+				
+				ArrayList<Integer> versOfObj = objsClassMap.get(objIdStr.toString());
+				versOfObj.add(ver.getId());
+				
+				for (Attribute attribute : attsToVerAttsMap.keySet()) {
+					String v = example.getValueAsString(attribute);
+					SLEXMMAttribute attmm = attsToVerAttsMap.get(attribute);
+					SLEXMMAttributeValue attv = mm.createAttributeValue(
+							attmm.getId(), ver.getId(), v,
+							String.valueOf(attribute.getValueType()));
+				}
+				
+				if (!relsPerClassMap.containsKey(clmm.getId())) {
+					relsPerClassMap.put(clmm.getId(),
+							new HashMap<String, HashMap<Integer, HashMap<Integer, String>>>());
+				}
+				
+				HashMap<String, HashMap<Integer, HashMap<Integer, String>>> relsAux1 = 
+						relsPerClassMap.get(clmm.getId());
+				
+				if (!relsAux1.containsKey(objIdStr.toString())) {
+					relsAux1.put(objIdStr.toString(), new HashMap<Integer,HashMap<Integer,String>>());
+				}
+				
+				HashMap<Integer,HashMap<Integer,String>> relsAux2 =
+						relsAux1.get(objIdStr.toString());
+				
+				if (!relsAux2.containsKey(ver.getId())) {
+					relsAux2.put(ver.getId(), new HashMap<Integer,String>());
+				}
+				
+				HashMap<Integer, String> relsAux3 = relsAux2.get(ver.getId());
+				
+				if (fks != null) {
+					for (DataModelMMKey fk : fks) {
+						StringBuilder targetObjId = new StringBuilder();
+						for (String atStr : fk.getAttributesMap().keySet()) {
+							Attribute at = atts.get(atStr);
+							targetObjId.append(example.getValueAsString(at));
+							targetObjId.append('#');
+						}
+						relsAux3.put(fk.getRelationshipId(),
+								targetObjId.toString());
+					}
+				}
+				
+				if (i >= 100) {
+					mm.commit();
+					i = 0L;
+				} else {
+					i++;
+				}
+				
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+		}
+	}
+	
+	private void importVersions(IOObjectCollection<ExampleSet> verCol,
+			DataModelMM dm, SLEXMMStorageMetaModel mm, HashMap<Double,Integer> verIdMap) throws Exception {
+		
+		List<ExampleSet> verColList = verCol.getObjects();
+		
+		HashMap<Integer, // ClassID
+			HashMap<String, // ObjIDStr
+				Integer // ObjID
+			>
+		> objPerClassMap = new HashMap<>();
+		
+		HashMap<Integer, // Class ID
+			HashMap<String, // ObjIDStr
+				HashMap<Integer, // Version ID
+					HashMap<Integer, // Relationship ID
+						String> // ObjIDStr
+				>
+			>
+		> relsPerClassMap = new HashMap<>();
+		
+		HashMap<Integer, // Class ID
+			HashMap<String, // objIDStr
+				ArrayList<Integer>  // version ID
+			>
+		> versionsPerClassMap = new HashMap<>();
+		
+		HashMap<Double,Long> startTimePerExample = new HashMap<>(); // start timestamp per Example ID
+		HashMap<Double,Long> endTimePerExample = new HashMap<>(); // end timestamp per Example ID
+		
+		HashMap<Integer,Long> startTimePerVersion = new HashMap<>(); // start timestamp per version ID
+		HashMap<Integer,Long> endTimePerVersion = new HashMap<>(); // end timestamp per version ID
+		
+		HashMap<Integer,Integer> targetClassPerRelationship = new HashMap<>(); // class Id per Relationship ID
+		
+		Long i = 0L;
+				
+		for (ExampleSet verExSet : verColList) {
+			
+			Annotations an = verExSet.getAnnotations();
+			String file_name = an.getAnnotation(VER_EXSET_ANNOTATION_FILE_NAME);
+			String datamodel_name = an.getAnnotation(VER_EXSET_ANNOTATION_DATAMODEL_NAME);
+			String class_name = an.getAnnotation(VER_EXSET_ANNOTATION_CLASS_NAME);
+			String startTimestamp = an.getAnnotation(VER_EXSET_ANNOTATION_START_TIMESTAMP);
+			String endTimestamp = an.getAnnotation(VER_EXSET_ANNOTATION_END_TIMESTAMP);
+			String timestampFormat = an.getAnnotation(VER_EXSET_ANNOTATION_TIMESTAMP_FORMAT);
+			Attribute attId = verExSet.getAttributes().getId();
+			if (attId == null) {
+				throw new Exception("no Id attribute set in ExampleSet "+verExSet.getName()); 
+			}
+			
+			System.out.println("FileName: "+file_name);
+			
+			SimpleDateFormat dateFormatter = null;
+			if (timestampFormat != null) {
+				dateFormatter = new SimpleDateFormat(timestampFormat);
+			} else {
+				dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+			}
+			
+			SLEXMMClass clmm = dm.getClassForName(datamodel_name, class_name);
+			
+			if (!objPerClassMap.containsKey(clmm.getId())) {
+				objPerClassMap.put(clmm.getId(), new HashMap<String,Integer>());
+			}
+			
+			HashMap<String,Integer> objMap = objPerClassMap.get(clmm.getId());
+			
+			HashMap<Attribute,SLEXMMAttribute> attsToVerAttsMap = new HashMap<>();
+			Attributes atts = verExSet.getAttributes();
+						
+			for (Attribute at : atts) {
+				SLEXMMAttribute vAt = dm.getAttributeForName(clmm, at.getName());
+				if (vAt != null) {
+					attsToVerAttsMap.put(at, vAt);
+				}
+			}
+			
+			Attribute startTimestampAtt = atts.get(startTimestamp, false);
+			Attribute endTimestampAtt = null;
+			if (endTimestamp != null) {
+				endTimestampAtt = atts.get(endTimestamp, false);
+			}
+						
+			List<Attribute> pkListAtts = new ArrayList<>();
+			DataModelMMKey pk = dm.getPKForClass(clmm);
+			for (String pkAt : pk.getAttributesMap().keySet()) {
+				Attribute at = atts.get(pkAt,false);
+				pkListAtts.add(at);
+			}
+			
+			HashMap<DataModelMMKey,List<Attribute>> fkAttrMap = new HashMap<>();
+			List<DataModelMMKey> fks = dm.getFKsForClass(clmm);
+			if (fks != null) {
+				for (DataModelMMKey fk : fks) {
+					SLEXMMClass targetClass = dm.getClassForName(datamodel_name, fk.getTargetClass());
+					if (targetClass != null) {
+						Integer targetClassId = targetClass.getId();
+						targetClassPerRelationship.put(fk.getRelationshipId(),targetClassId);
+					}
+					List<Attribute> fkListAtts = new ArrayList<>();
+					fkAttrMap.put(fk, fkListAtts);
+					for (String fkAt : fk.getAttributesMap().keySet()) {
+						Attribute at = atts.get(fkAt, false);
+						fkListAtts.add(at);
+					}
+				}
+			}
+			
+			computeEndTimestampsVersions(verExSet, pkListAtts, clmm, dateFormatter,
+					 startTimestampAtt, endTimestampAtt, startTimePerExample, endTimePerExample);
+			
+			parseRows(verExSet, pkListAtts, objMap, i, clmm, mm, versionsPerClassMap,
+					 startTimePerExample, startTimePerVersion, endTimePerExample, 
+					 endTimePerVersion, attsToVerAttsMap,
+					 relsPerClassMap, fks, atts, verIdMap);
+		}
+		
+		mm.commit();
+		
+		i = 0L;
+		
+		// Go through versions and create relations
+		for (Integer clId : relsPerClassMap.keySet()) {
+			for (String objId : relsPerClassMap.get(clId).keySet()) {
+				for (Integer vId : relsPerClassMap.get(clId).get(objId)
+						.keySet()) {
+
+					long sStartTimestamp = startTimePerVersion.get(vId);
+					long sEndTimestamp = endTimePerVersion.get(vId);
+
+					for (Integer rsId : relsPerClassMap.get(clId).get(objId)
+							.get(vId).keySet()) {
+						String targetObjId = relsPerClassMap.get(clId)
+								.get(objId).get(vId).get(rsId);
+						Integer tclId = targetClassPerRelationship.get(rsId);
+						ArrayList<Integer> tvlist = versionsPerClassMap
+								.get(tclId).get(targetObjId);
+						if (tvlist != null) {
+							for (Integer tvid : tvlist) {
+								long tStartTimestamp = startTimePerVersion
+										.get(tvid);
+								long tEndTimestamp = endTimePerVersion
+										.get(tvid);
+
+								if (beforeOrEqual(tStartTimestamp,sEndTimestamp)
+										&& afterOrEqual(tEndTimestamp,sStartTimestamp)) {
+									long relationStartTimestamp = latest(
+											sStartTimestamp, tStartTimestamp);
+									long relationEndTimestamp = earliest(
+											sEndTimestamp, tEndTimestamp);
+
+									SLEXMMRelation rel = mm.createRelation(vId,
+											tvid, rsId, relationStartTimestamp,
+											relationEndTimestamp);
+
+									if (i >= 100) {
+										mm.commit();
+										i = 0L;
+									} else {
+										i++;
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		
+		mm.commit();
+	}
+	
+	private boolean beforeOrEqual(long a, long b) {
+		return (a <= b || a == -2 || b == -1);
+	}
+	
+	private boolean afterOrEqual(long a, long b) {
+		return (a >= b || a == -1 || b == -2);
+	}
+	
+	private long latest(long a, long b) {
+		if (a == -1 || b == -1) {
+			return -1;
+		} else {
+			return Math.max(a,b);
+		}
+	}
+	
+	private long earliest(long a, long b) {
+		if (a == -2 || b == -2) {
+			return -2;
+		} else if (a == -1 || b == -1) {
+			return Math.max(a,b);
+		} else {
+			return Math.min(a,b);
+		}
+	}
+	
+	private boolean isEmptyAnnotation(String v) {
+		return (v == null || v.isEmpty() || v.equalsIgnoreCase("?"));
+	}
+	
+	private void importEvents(IOObjectCollection<ExampleSet> evCol, SLEXMMStorageMetaModel mm,
+			HashMap<Double,Integer> verIdMap,
+			HashMap<Integer,SLEXMMActivityInstance> eventsToAIMap) {
+		
+		List<ExampleSet> evColList = evCol.getObjects();
+		int order = 1;
+		int lastCommitOrder = 0;
+		for (ExampleSet evExSet : evColList) {
+			
+			HashMap<String,Integer> actInsMap = new HashMap<>();
+			HashMap<String,SLEXMMActivity> actMap = new HashMap<>();
+			
+			Annotations an = evExSet.getAnnotations();
+			String file_name = an.getAnnotation(EV_EXSET_ANNOTATION_FILE_NAME);
+			String timestamp = an.getAnnotation(EV_EXSET_ANNOTATION_TIMESTAMP);
+			String timestampFormat = an.getAnnotation(EV_EXSET_ANNOTATION_TIMESTAMP_FORMAT);
+			String activity = an.getAnnotation(EV_EXSET_ANNOTATION_ACTIVITY);
+			String activity_ins = an.getAnnotation(EV_EXSET_ANNOTATION_ACTIVITY_INSTANCE);
+			String lifecycle = an.getAnnotation(EV_EXSET_ANNOTATION_LIFECYCLE);
+			String resource = an.getAnnotation(EV_EXSET_ANNOTATION_RESOURCE);
+			
+			SimpleDateFormat dateFormatter = null;
+			if (timestampFormat != null) {
+				dateFormatter = new SimpleDateFormat(timestampFormat);
+			} else {
+				dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+			}
+			
+			boolean hasTimestamp = true;
+			boolean hasActivity = true;
+			boolean hasActivityInstance = true;
+			boolean hasLifecycle = true;
+			boolean hasResource = true;
+			
+			if (isEmptyAnnotation(timestamp)) {
+				hasTimestamp = false;
+			}
+			
+			if (isEmptyAnnotation(activity)) {
+				hasActivity = false;
+			}
+			
+			if (isEmptyAnnotation(activity_ins)) {
+				hasActivityInstance = false;
+			}
+			
+			if (isEmptyAnnotation(lifecycle)) {
+				hasLifecycle = false;
+			}
+			
+			if (isEmptyAnnotation(resource)) {
+				hasResource = false;
+			}
+			
+			HashMap<Attribute,SLEXMMEventAttribute> attsToEvAttsMap = new HashMap<>();
+			Attributes atts = evExSet.getAttributes();
+			for (Attribute at : atts) {
+				SLEXMMEventAttribute evAt = mm.createEventAttribute(at.getName());
+				attsToEvAttsMap.put(at, evAt);
+			}
+			
+			Attribute timestampAtt = null;
+			Attribute activityAtt = null;
+			Attribute activity_insAtt = null;
+			Attribute lifecycleAtt = null;
+			Attribute resourceAtt = null;
+			
+			if (hasTimestamp) {
+				timestampAtt = atts.get(timestamp, false);
+			}
+			
+			if (hasActivity) {
+				activityAtt = atts.get(activity, false);
+			}
+			
+			if (hasActivityInstance) {
+				activity_insAtt = atts.get(activity_ins, false);
+			}
+			
+			if (hasLifecycle) {
+				lifecycleAtt = atts.get(lifecycle, false);
+			}
+			
+			if (hasResource) {
+				resourceAtt = atts.get(resource, false);
+			}
+			
+			for (Example example : evExSet) {
+				
+				SLEXMMActivity activitymm = null;
+				String activityV = null;
+				if (hasActivity) {
+					activityV = example.getValueAsString(activityAtt);
+					activitymm = actMap.get(activityV);
+					if (activitymm == null) {
+						activitymm = mm.createActivity(activityV);
+						actMap.put(activityV, activitymm);
+					}
+				}
+				
+				SLEXMMActivityInstance ai = null;
+				Integer actInsId = null;
+				if (hasActivityInstance) {
+					String activityInsV = example.getValueAsString(activity_insAtt);
+					if (activityInsV != null) {
+						actInsId = actInsMap.get(activityInsV);
+						if (actInsId == null) {
+							if (activitymm != null) {
+								ai = mm.createActivityInstance(activitymm);
+								actInsId = ai.getId();
+								actInsMap.put(activityInsV, actInsId);
+							}
+						}
+					}
+				}
+				if (actInsId == null) {
+					if (activitymm != null) {
+						ai = mm.createActivityInstance(activitymm);
+						actInsId = ai.getId();
+					} else {
+						actInsId = -1;
+					}
+				}
+								
+				String timestampV = null;
+				long timestampL = 0L;
+				if (hasTimestamp) {
+					timestampV = example.getValueAsString(timestampAtt);
+					if (timestampV != null) {
+						try {
+							timestampL = dateFormatter.parse(timestampV).getTime();
+						} catch (ParseException e1) {
+							e1.printStackTrace();
+						}
+					}
+				}
+				
+				String lifecycleV = null;
+				if (hasLifecycle) {
+					lifecycleV = example.getValueAsString(lifecycleAtt);
+				}
+				
+				String resourceV = null;
+				if (hasResource) {
+					resourceV = example.getValueAsString(resourceAtt);
+				}
+				
+				SLEXMMEvent e = mm.createEvent(order, actInsId, lifecycleV, resourceV, timestampL);
+				verIdMap.put(example.getId(), e.getId());
+				
+				if (ai != null) {
+					eventsToAIMap.put(e.getId(), ai);
+				}
+				
+				for (Attribute at : atts) {
+					String v = example.getValueAsString(at);
+					mm.createEventAttributeValue(
+							attsToEvAttsMap.get(at).getId(), e.getId(), v,
+							String.valueOf(at.getValueType()));
+				}
+				
+				if (order - lastCommitOrder >= 100) {
+					mm.commit();
+					lastCommitOrder = order;
+				}
+			}
+			
+			mm.commit();
+		}
+	}
+	
+	public List<ParameterType> getParameterTypes() {
+		List<ParameterType> types = super.getParameterTypes();
+		types.add(new ParameterTypeFile(PARAMETER_KEY, PARAMETER_DESC,
+				false, SUPPORTED_FILE_FORMATS));
+//		ParameterType queryType = new ParameterTypeString(PARAMETER_1,PARAMETER_1,"",true);
+//		parameterTypes.add(queryType);
+//		ParameterType type =
+//				new ParameterTypeConfiguration(DAPOQLangDialogCreator.class, this);
+//        type.setExpert(false);
+//        parameterTypes.add(type);
+		
+		return types;
+	}
+	
+}

--- a/RapidProM/src/org/rapidprom/operators/io/ImportSLEXMMOperator.java
+++ b/RapidProM/src/org/rapidprom/operators/io/ImportSLEXMMOperator.java
@@ -1,0 +1,81 @@
+package org.rapidprom.operators.io;
+
+import java.io.File;
+import java.util.List;
+
+import org.processmining.openslex.metamodel.SLEXMMStorageMetaModelImpl;
+import org.rapidprom.ioobjectrenderers.SLEXMMIOObjectVisualizationType;
+import org.rapidprom.ioobjects.SLEXMMIOObject;
+import org.rapidprom.operators.abstr.AbstractRapidProMImportOperator;
+import org.rapidprom.operators.extract.ExtractXLogOperator;
+import org.rapidprom.operators.extract.ExtractXLogOperator.ImplementingPlugin;
+
+import com.rapidminer.operator.OperatorDescription;
+import com.rapidminer.parameter.ParameterType;
+import com.rapidminer.parameter.ParameterTypeCategory;
+import com.rapidminer.parameter.ParameterTypeFile;
+
+/**
+ * The ImportXLLogOperator uses public static methods from the
+ * {@link ExtractXLogOperator} for actually importing the event log. This is
+ * mainly due to the fact that java does not support multiple-inheritance.
+ * 
+ */
+public class ImportSLEXMMOperator
+		extends AbstractRapidProMImportOperator<SLEXMMIOObject> {
+
+//	private final static String PARAMETER_KEY_IMPORTER = "importer";
+//	private final static String PARAMETER_DESC_IMPORTER = "Select the implementing importer, importers differ in terms of performance: "
+//			+ "The \"Naive\" importer loads the Log completely in memory (faster, but more memory usage). "
+//			+ "The \"Buffered by MAPDB\" importer loads only log, trace and event ids, "
+//			+ "and the rest of the data (mainly attribute values) are stored in disk by MapDB "
+//			+ "(slower, but less memory usage). "
+//			+ "The \"Lightweight & Sequential IDs\" importer is a balance between the \"Naive\" and the \"Buffered by MapDB\" importers";
+
+//	private final static ImplementingPlugin[] PARAMETER_OPTIONS_IMPORTER = EnumSet
+//			.allOf(ImplementingPlugin.class)
+//			.toArray(new ImplementingPlugin[EnumSet
+//					.allOf(ImplementingPlugin.class).size()]);
+
+	private final static String[] SUPPORTED_FILE_FORMATS = new String[] { "slexmm" };
+
+	public ImportSLEXMMOperator(OperatorDescription description) {
+		super(description, SLEXMMIOObject.class, SUPPORTED_FILE_FORMATS);
+	}
+
+//	@SuppressWarnings("unchecked")
+//	@Override
+//	public MetaData getGeneratedMetaData() throws OperatorException {
+//		getLogger().fine("Generating meta data for " + this.getName());
+//		return new SLEXMMIOObjectMetaData();
+//	}
+
+	protected SLEXMMIOObject read(File file) throws Exception {
+		String fileDir = file.getParent();
+		String fileName = file.getName();
+		SLEXMMStorageMetaModelImpl mm = new SLEXMMStorageMetaModelImpl(fileDir, fileName);
+		SLEXMMIOObject obj = new SLEXMMIOObject(mm);
+		
+		obj.setVisualizationType(SLEXMMIOObjectVisualizationType.DEFAULT);
+		return obj;
+	}
+
+	@Override
+	public List<ParameterType> getParameterTypes() {
+		List<ParameterType> types = super.getParameterTypes();
+		types.add(new ParameterTypeFile(PARAMETER_KEY_FILE, PARAMETER_DESC_FILE,
+				false, SUPPORTED_FILE_FORMATS));
+//		types.add(createImporterParameterTypeCategory(PARAMETER_KEY_IMPORTER,
+//				PARAMETER_DESC_IMPORTER, PARAMETER_OPTIONS_IMPORTER));
+		return types;
+	}
+
+//	private ParameterType createImporterParameterTypeCategory(String key,
+//			String desc, ImplementingPlugin[] importers) {
+//		String[] importersStr = new String[importers.length];
+//		for (int i = 0; i < importersStr.length; i++) {
+//			importersStr[i] = importers[i].toString();
+//		}
+//		return new ParameterTypeCategory(key, desc, importersStr, 0, true);
+//	}
+}

--- a/RapidProM/src/org/rapidprom/operators/logmanipulation/AddTraceAttributesToLogOperator.java
+++ b/RapidProM/src/org/rapidprom/operators/logmanipulation/AddTraceAttributesToLogOperator.java
@@ -1,6 +1,7 @@
 package org.rapidprom.operators.logmanipulation;
 
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.logging.Level;
@@ -107,14 +108,30 @@ public class AddTraceAttributesToLogOperator extends Operator {
 		return parameterTypes;
 	}
 
+	private HashMap<String,XTrace> buildTraceMap(XLog xlog) {
+		HashMap<String,XTrace> map = new HashMap<>();
+		
+		for (XTrace t : xlog) {
+			String name = XConceptExtension.instance().extractName(t);
+			if (name != null) {
+				map.put(name, t);
+			}
+		}
+		
+		return map;
+	}
+	
 	private XLog mergeExampleSetIntoLog(XLog xLog, ExampleSet es,
 			String nameIDcolumn, Attribute idColumnAttrib) throws UndefinedParameterError {
+		
+		HashMap<String,XTrace> traceMap = buildTraceMap(xLog);
+		
 		Iterator<Example> iterator = es.iterator();
 		while (iterator.hasNext()) {
 			Example example = iterator.next();
 			// get the case id and see if a corresponding trace can be found
 			String caseid = example.getValueAsString(idColumnAttrib);
-			XTrace t = findTrace(caseid, xLog);
+			XTrace t = traceMap.get(caseid);
 			if (t != null) {
 				Attributes attributes = example.getAttributes();
 				Iterator<Attribute> iterator2 = attributes.iterator();
@@ -155,16 +172,6 @@ public class AddTraceAttributesToLogOperator extends Operator {
 			}
 		}
 		return xLog;
-	}
-
-	private XTrace findTrace(String caseid, XLog xLog) {
-		for (XTrace t : xLog) {
-			String name = XConceptExtension.instance().extractName(t);
-			if (name.equals(caseid)) {
-				return t;
-			}
-		}
-		return null;
 	}
 
 }


### PR DESCRIPTION
For the "Add attributes to traces" operator, I modified the way traces are searched. Before, in the worse case scenario, the algorithm had a cost of n*m, being n the number of attribute sets and m the number of traces. Now, building a HashMap of the traces indexed by the trace identifier, the cost is n+m. The difference in running time is huge.

For the operator that builds XES logs from tables of events, the implementation has been changed to make use of the MapDB version of XES. This saves a lot of memory and allows to build logs that otherwise would not fit in RAM.
